### PR TITLE
add 3.9.7-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ RabbitMQ with management and compatible version of the delayed message exchange 
 ## Versions
 - [latest](https://github.com/heidiks/rabbitmq-delayed-message-exchange/blob/master/versions/latest/Dockerfile)
 - 3.9.x:
+    - [3.9.7-management](https://github.com/heidiks/rabbitmq-delayed-message-exchange/blob/master/versions/3.9.7-management/Dockerfile)
     - [3.9.0-management](https://github.com/heidiks/rabbitmq-delayed-message-exchange/blob/master/versions/3.9.0-management/Dockerfile)
 - 3.8.x:
     - [3.8.9-management](https://github.com/heidiks/rabbitmq-delayed-message-exchange/blob/master/versions/3.8.9-management/Dockerfile)
@@ -48,5 +49,3 @@ The environment variables are the same as the [official image](https://hub.docke
 - Sample
     - RABBITMQ_DEFAULT_USER=admin
     - RABBITMQ_DEFAULT_PASS=password
-
-

--- a/versions/3.9.7-management/Dockerfile
+++ b/versions/3.9.7-management/Dockerfile
@@ -1,0 +1,13 @@
+FROM rabbitmq:3.9.7-management
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
+
+RUN curl -fsSL \
+	-o "$RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.9.0.ez" \
+	https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.9.0/rabbitmq_delayed_message_exchange-3.9.0.ez
+
+RUN chown rabbitmq:rabbitmq $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.9.0.ez
+
+RUN rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
+
+RUN rabbitmq-plugins enable --offline rabbitmq_consistent_hash_exchange


### PR DESCRIPTION
rabbitmq:3.9.0-management doesn't allow using environment variables to set username or password

see https://github.com/docker-library/rabbitmq/issues/508

This was fixed in 3.9.4